### PR TITLE
Fixed mistake in type signature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The `nub` function removes duplicate elements from lists.
 It can be defined as:
 
 ```
-nub :: Eq => [a] -> [a]
+nub :: Eq a => [a] -> [a]
 nub []     =  []
 nub (x:xs) =  x : nub (filter (x/=) xs)
 ```


### PR DESCRIPTION
I found this line:

``` Haskell
nub :: Eq => [a] -> [a]
```

I imagine this is what you meant:

``` Haskell
nub :: Eq a => [a] -> [a]
```
