### PR TITLE
Made TH error into a compiler error

### DIFF
--- a/src/IfCxt.hs
+++ b/src/IfCxt.hs
@@ -64,4 +64,4 @@ mkIfCxtInstances n = do
                     ]
                 ]
 
-        otherwise -> error $ show n ++ " not a class name"
+        otherwise -> fail $ show n ++ " is not a class name."


### PR DESCRIPTION
It says [here](http://hackage.haskell.org/package/template-haskell-2.10.0.0/docs/Language-Haskell-TH-Syntax.html#v:reportError) in the source of `Language.Haskell.TH` that one should use `fail` to report errors and stop the computation, so I have replaced `error` with `fail`. I also prettified the message a tiny bit.
