### PR TITLE
Wrap constraints in `IfCxt`

### DIFF
--- a/ifcxt.cabal
+++ b/ifcxt.cabal
@@ -2,7 +2,7 @@
 --  see http://haskell.org/cabal/users-guide/
 
 name:                ifcxt
-version:             0.1.0.0
+version:             0.1.0.1
 synopsis:            put if statements within type constraints
 description:
 

--- a/ifcxt.cabal
+++ b/ifcxt.cabal
@@ -60,3 +60,14 @@ library
   build-depends:       base >=4.8 && <4.9, template-haskell >=2.10 && <2.11
   hs-source-dirs:      src
   default-language:    Haskell2010
+
+test-suite test
+  default-language:    Haskell2010
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      test
+  main-is:             Main.hs
+  build-depends:       base >= 4.8
+                     , ifcxt
+                     , QuickCheck
+                     , tasty >= 0.7
+                     , tasty-quickcheck

--- a/src/IfCxt.hs
+++ b/src/IfCxt.hs
@@ -40,7 +40,7 @@ mkIfCxtInstances n = do
 
     info <- reify n
     case info of
-        ClassI _ xs -> fmap concat $ forM xs $ \(InstanceD cxt (AppT classt t) _) -> return $
+        ClassI _ xs -> fmap concat $ forM xs $ \(InstanceD cxt (AppT classt t) ys) -> return $
             if isInstanceOfIfCxt (AppT classt t)
                then []
                else mkInstance cxt classt t n
@@ -72,9 +72,10 @@ relaxCxt t                                  = AppT (ConT ''IfCxt) t
 -- constraints, e.g. deriving "IfCxt (Show Bool)" from "Show Bool", we simply
 -- return the first argument.
 --
--- If we have extra constraints, e.g. deriving "IfCxt (Show [a], Show a)" from
--- "Show a => Show [a]", we call "ifCxt" recursively to bring those instances in
--- scope. We only return the first argument if all constraints are satisfied.
+-- If we have extra constraints, e.g. deriving
+-- "IfCxt (Show a) => IfCxt(Show [a])" from "Show a => Show [a]", we call
+-- "ifCxt" recursively to bring those instances in scope. We only return the
+-- first argument if all constraints are satisfied.
 mkIfCxtFun :: Cxt -> Exp
 mkIfCxtFun []     = VarE $ mkName "t"
 mkIfCxtFun (c:cs) = AppE (AppE (AppE (VarE 'ifCxt)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE RankNTypes, FlexibleInstances, FlexibleContexts, KindSignatures, ScopedTypeVariables, TemplateHaskell, ConstraintKinds #-}
+
+module Main where
+
+import           Data.Maybe
+import           Data.Typeable
+import           IfCxt
+import           Test.Tasty             (defaultMain, testGroup, localOption)
+import           Test.Tasty.QuickCheck
+
+mkIfCxtInstances ''Ord
+
+main = defaultMain $ testGroup "All tests" [
+    testProperty "Find Ord for Int"   haveLTEInt
+  , testProperty "Find Ord for [Int]" haveLTEListInt
+  ]
+
+-- Tests
+
+haveLTEInt     = isJust $ getLTE (Proxy :: Proxy Int)
+haveLTEListInt = isJust $ getLTE (Proxy :: Proxy [Int])
+
+-- Helpers
+
+getLTE :: forall proxy a. (IfCxt (Ord a)) => proxy a -> Maybe (a -> a -> Bool)
+getLTE _ = ifCxt (Proxy :: Proxy (Ord a))
+                 (Just (<=))
+                 Nothing

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -19,6 +19,10 @@ main = defaultMain $ testGroup "All tests" [
   , testProperty       "Get Ord for [Int]"            haveOrdListInt
   , testProperty "Can't get Ord for (Int -> Int)"       noOrdFuncInt
   , testProperty "Can't get Ord for [Int -> Int]"       noOrdListFuncInt
+  , testProperty   "Can use Ord for Int"            usableOrdInt
+  , testProperty   "Can use Ord for [Int]"          usableOrdListInt
+  , testProperty   "Can use Ord for (Int -> Int)" unusableOrdFuncInt
+  , testProperty   "Can use Ord for [Int -> Int]" unusableOrdListFuncInt
   ]
 
 -- Tests
@@ -28,14 +32,28 @@ findOrdListInt         = ifCxt (Proxy :: Proxy (Ord [Int]))        True  False
 notFoundOrdFuncInt     = ifCxt (Proxy :: Proxy (Ord (Int -> Int))) False True
 notFoundOrdListFuncInt = ifCxt (Proxy :: Proxy (Ord [Int -> Int])) False True
 
-haveOrdInt       = isJust    $ getLTE (Proxy :: Proxy Int)
-haveOrdListInt   = isJust    $ getLTE (Proxy :: Proxy [Int])
-noOrdFuncInt     = isNothing $ getLTE (Proxy :: Proxy (Int -> Int))
-noOrdListFuncInt = isNothing $ getLTE (Proxy :: Proxy [Int -> Int])
+haveOrdInt       = isJust    $ getLTE (Proxy :: Proxy (Ord Int))
+haveOrdListInt   = isJust    $ getLTE (Proxy :: Proxy (Ord [Int]))
+noOrdFuncInt     = isNothing $ getLTE (Proxy :: Proxy (Ord (Int -> Int)))
+noOrdListFuncInt = isNothing $ getLTE (Proxy :: Proxy (Ord [Int -> Int]))
+
+usableOrdInt       (x :: Int)   y =   usableLTE x y
+usableOrdListInt   (x :: [Int]) y =   usableLTE x y
+unusableOrdFuncInt (x :: Int)   y = unusableLTE (+x) (*y)
+unusableOrdListFuncInt            = unusableLTE ([] :: [Int -> Int]) []
 
 -- Helpers
 
-getLTE :: forall proxy a. (IfCxt (Ord a)) => proxy a -> Maybe (a -> a -> Bool)
+getLTE :: forall proxy a. IfCxt (Ord a) => proxy (Ord a) -> Maybe (a -> a -> Bool)
 getLTE _ = ifCxt (Proxy :: Proxy (Ord a))
                  (Just (<=))
                  Nothing
+
+useLTE :: (IfCxt (Ord a)) => a -> a -> Maybe Bool
+useLTE x y = getLTE (Proxy :: Proxy (Ord a)) <*> pure x <*> pure y
+
+usableLTE :: (IfCxt (Ord a), Ord a) => a -> a -> Bool
+usableLTE x y = useLTE x y == Just (x <= y)
+
+unusableLTE :: (IfCxt (Ord a)) => a -> a -> Bool
+unusableLTE x y = useLTE x y == Nothing

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -11,14 +11,17 @@ import           Test.Tasty.QuickCheck
 mkIfCxtInstances ''Ord
 
 main = defaultMain $ testGroup "All tests" [
-    testProperty "Find Ord for Int"   haveLTEInt
-  , testProperty "Find Ord for [Int]" haveLTEListInt
+    testProperty "Find Ord for Int"        haveOrdInt
+  , testProperty "Find Ord for [Int]"      haveOrdListInt
+  , testProperty "No Ord for (Int -> Int)" noOrdFuncInt
   ]
 
 -- Tests
 
-haveLTEInt     = isJust $ getLTE (Proxy :: Proxy Int)
-haveLTEListInt = isJust $ getLTE (Proxy :: Proxy [Int])
+haveOrdInt     = isJust $ getLTE (Proxy :: Proxy Int)
+haveOrdListInt = isJust $ getLTE (Proxy :: Proxy [Int])
+
+noOrdFuncInt = isNothing $ getLTE (Proxy :: Proxy (Int -> Int))
 
 -- Helpers
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE RankNTypes, FlexibleInstances, FlexibleContexts, KindSignatures, ScopedTypeVariables, TemplateHaskell, ConstraintKinds #-}
+{-# LANGUAGE RankNTypes, FlexibleInstances, FlexibleContexts, KindSignatures, ScopedTypeVariables, TemplateHaskell, ConstraintKinds, IncoherentInstances #-}
 
 module Main where
 
@@ -11,17 +11,27 @@ import           Test.Tasty.QuickCheck
 mkIfCxtInstances ''Ord
 
 main = defaultMain $ testGroup "All tests" [
-    testProperty "Find Ord for Int"        haveOrdInt
-  , testProperty "Find Ord for [Int]"      haveOrdListInt
-  , testProperty "No Ord for (Int -> Int)" noOrdFuncInt
+    testProperty      "Find Ord for Int"              findOrdInt
+  , testProperty      "Find Ord for [Int]"            findOrdListInt
+  , testProperty        "No Ord for (Int -> Int)" notFoundOrdFuncInt
+  , testProperty        "No Ord for [Int -> Int]" notFoundOrdListFuncInt
+  , testProperty       "Get Ord for Int"              haveOrdInt
+  , testProperty       "Get Ord for [Int]"            haveOrdListInt
+  , testProperty "Can't get Ord for (Int -> Int)"       noOrdFuncInt
+  , testProperty "Can't get Ord for [Int -> Int]"       noOrdListFuncInt
   ]
 
 -- Tests
 
-haveOrdInt     = isJust $ getLTE (Proxy :: Proxy Int)
-haveOrdListInt = isJust $ getLTE (Proxy :: Proxy [Int])
+findOrdInt             = ifCxt (Proxy :: Proxy (Ord Int))          True  False
+findOrdListInt         = ifCxt (Proxy :: Proxy (Ord [Int]))        True  False
+notFoundOrdFuncInt     = ifCxt (Proxy :: Proxy (Ord (Int -> Int))) False True
+notFoundOrdListFuncInt = ifCxt (Proxy :: Proxy (Ord [Int -> Int])) False True
 
-noOrdFuncInt = isNothing $ getLTE (Proxy :: Proxy (Int -> Int))
+haveOrdInt       = isJust    $ getLTE (Proxy :: Proxy Int)
+haveOrdListInt   = isJust    $ getLTE (Proxy :: Proxy [Int])
+noOrdFuncInt     = isNothing $ getLTE (Proxy :: Proxy (Int -> Int))
+noOrdListFuncInt = isNothing $ getLTE (Proxy :: Proxy [Int -> Int])
 
 -- Helpers
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE RankNTypes, FlexibleInstances, FlexibleContexts, KindSignatures, ScopedTypeVariables, TemplateHaskell, ConstraintKinds, IncoherentInstances #-}
+{-# LANGUAGE RankNTypes, FlexibleInstances, FlexibleContexts, KindSignatures, ScopedTypeVariables, TemplateHaskell, ConstraintKinds #-}
 
 module Main where
 


### PR DESCRIPTION
Wrap instance constraints in `IfCxt`. Previously, `mkIfCxtInstances` would turn instances like `Ord a => Ord [a]` into `Ord a => IfCxt (Ord [a])`, which places hard constraints on how we can use `ifCxt`.

This patch wraps the constraints in `IfCxt` as well, so we would get `IfCxt (Ord a) => IfCxt (Ord [a])`. The implementations of `ifCxt` will now call each other recursively to resolve all of these constraints, rather than committing to the first argument and introducing unsatisfiable constraints.

I've also added a test suite and bumped the version to 0.1.0.1
